### PR TITLE
Improve text sanitization with Unicode normalization

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -1,5 +1,18 @@
 """Defines utility functions."""
 
+import unicodedata
+
 
 def aggressively_sanitize(string: str) -> str:
-    return string.replace("Â", "").replace("Ã", "")
+    """Remove stray Unicode characters and normalize to ASCII.
+
+    Many external data sources include mis-encoded bytes that show up as
+    unexpected characters (for example ``Â`` or ``Ã``), as well as
+    diacritics and non-breaking spaces.  This helper strips those common
+    artifacts and falls back to a Unicode normalization/ASCII encoding
+    pass so that downstream parsers work with clean text.
+    """
+
+    string = string.replace("Â", "").replace("Ã", "")
+    normalized = unicodedata.normalize("NFKD", string).replace("\u00a0", " ")
+    return normalized.encode("ascii", "ignore").decode()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,6 @@
+import src.util as util
+
+
+def test_aggressively_sanitize_removes_unicode_noise():
+    raw = "ÂÃJosé\u00a0García\u200b"
+    assert util.aggressively_sanitize(raw) == "Jose Garcia"


### PR DESCRIPTION
## Summary
- Normalize and strip stray Unicode in `aggressively_sanitize` for robust parsing
- Add test covering removal of mis-encoded characters and spaces

## Testing
- `PYTHONPATH=. pytest -q`
- `PYTHONPATH=. pre-commit run --files src/util.py tests/test_util.py` *(fails: pyright type errors, pytest hook missing optional dependency `dev`)*


------
https://chatgpt.com/codex/tasks/task_e_68942fc664e4832689240c1121a0c0a5