### PR TITLE
Revamp draft value calculations with curve-fit parameters

### DIFF
--- a/src/infra.py
+++ b/src/infra.py
@@ -8,8 +8,8 @@ import bs4
 import numpy
 from bs4 import BeautifulSoup, Tag
 
-import settings
-import util
+from . import settings
+from . import util
 
 DATA_DIR_PATH: str = os.path.join(os.path.dirname(__file__), "..", "data")
 


### PR DESCRIPTION
## Summary
- rank remaining players after excluding taken names using position-specific fitted curves
- compute draft value with learned parameters and offer an optimal draft pick helper
- filter outliers in QB curve fitting and fix relative imports

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6894958c6f4c8326950bc8d44297b80a